### PR TITLE
Fixed cache directory not found error on macOS

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -41,7 +41,11 @@ fn cache_path(file_name: &str) -> String {
 
         result = format!("{}\\{}", path, file_name)
     } else if os == "macos" {
-        let path = "~/Library/Caches/dictionary-cli".to_string();
+        let path = format!(
+            "{}/{}", 
+            std::env::home_dir().expect("No home dir").display().to_string(),
+            "Library/Caches/dictionary-cli".to_string()
+        );
         create_not_exist_path(&path);
         result = format!("{}/{}", path, file_name)
     }


### PR DESCRIPTION
The ```"~"``` used in the path ```"~/Library/Caches/dictionary-cli"``` wasn't being parsed correctly which resulted in an error as the path couldn't be found even if it existed.  I used ```std::env::home_dir()``` to get the home directory instead, which works.

Using ```std::env::home_dir()``` gives a deprecation warning, but as far as I can tell this is only because the function has unclear behavior on Windows. Since the OS has to be macOS for this line to run, I figured it should be fine. 